### PR TITLE
노트를 처리할 시 기존의 미리보기용 노트는 삭제하도록 함 (최적화 용도)

### DIFF
--- a/Vexatonic_Dash/Assets/Scripts/Notes/Note.cs
+++ b/Vexatonic_Dash/Assets/Scripts/Notes/Note.cs
@@ -18,6 +18,8 @@ public class Note : MonoBehaviour
     public Vector3 startPos; // 이 노트에서 움직이는 캐릭터의 시작 위치
     public Vector3 endPos;  // 이 노트에서 움직이는 캐릭터의 끝 위치
 
+    public GameObject parentNote = null; // 움직이는 노트의 목적지에 있는 고정된 노트.
+
 
     public void Deactivate() {
         activated = false;
@@ -35,6 +37,7 @@ public class Note : MonoBehaviour
 
     public void FixNote() {
         permanent = true;
+        if (parentNote != null) Destroy(parentNote);
         transform.position = destPos;
     }
 

--- a/Vexatonic_Dash/Assets/Scripts/RhythmManager.cs
+++ b/Vexatonic_Dash/Assets/Scripts/RhythmManager.cs
@@ -114,7 +114,7 @@ public class RhythmManager : MonoBehaviour
 
         // InputManager 세팅
         GameManager.myManager.im.StartLoop(
-            new List<KeyCode> { KeyCode.F, KeyCode.J, KeyCode.R, KeyCode.U, KeyCode.Space },
+            new List<KeyCode> { KeyCode.F, KeyCode.J, KeyCode.D, KeyCode.K, KeyCode.Space },
             new List<NoteType> { NoteType.Normal, NoteType.Normal, NoteType.Dash, NoteType.Dash, NoteType.Jump }
         );
         StartCoroutine(nameof(StartReceivingInput));

--- a/Vexatonic_Dash/Assets/Scripts/RhythmManager.cs
+++ b/Vexatonic_Dash/Assets/Scripts/RhythmManager.cs
@@ -210,7 +210,6 @@ public class RhythmManager : MonoBehaviour
                 spawnedNotes.Dequeue();
                 note.FixNote();
                 myPlayer.MoveCharacter(note, gameTime);
-                Debug.Log("Time after destroying note:" + Time.time);
                 
                 // }
 
@@ -225,6 +224,7 @@ public class RhythmManager : MonoBehaviour
             if (temp.GetComponent<Note>().lifetime < -0.166f)
             {
                 Destroy(spawnedNotes.Dequeue());
+                //TODO: MISS여도 죽지 않게 되는 경우를 만드려면 여기서도 FixNote() 실행 필요.
                 AddJudgement(JudgementType.Miss);
             }
         }
@@ -340,6 +340,7 @@ public class RhythmManager : MonoBehaviour
                     Debug.Log($"noteEndTime: {movingNote.noteEndTime}");
                     movingNote.spawnPos = note.spawnPosition;
                     movingNote.destPos = AnchorPosition;
+                    movingNote.parentNote = platform;
                     AnchorPosition = movingNote.GetInformationForPlayer(inputWidth, AnchorPosition);
                     movingNote.Deactivate();
                     preSpawnedNotes.Enqueue(movingPlatform);
@@ -373,6 +374,7 @@ public class RhythmManager : MonoBehaviour
                     Debug.Log($"noteEndTime: {platformMovingNote.noteEndTime}");
                     platformMovingNote.spawnPos = dashNote.spawnPosition;
                     platformMovingNote.destPos = AnchorPosition;
+                    platformMovingNote.parentNote = platform;
                     AnchorPosition = platformMovingNote.GetInformationForPlayer(inputWidth, AnchorPosition);
                     platformMovingNote.Deactivate();
                     preSpawnedNotes.Enqueue(movingPlatform);
@@ -402,6 +404,7 @@ public class RhythmManager : MonoBehaviour
                     Debug.Log($"noteEndTime: {jumpMovingNote.noteEndTime}");
                     jumpMovingNote.spawnPos = jumpNote.spawnPosition;
                     jumpMovingNote.destPos = AnchorPosition;
+                    jumpMovingNote.parentNote = platform;
                     AnchorPosition = jumpMovingNote.GetInformationForPlayer(inputWidth, jumpNote.jumpHeight, AnchorPosition);
                     jumpMovingNote.Deactivate();
                     preSpawnedNotes.Enqueue(movingPlatform);


### PR DESCRIPTION
사소한 변경이지만 RhythmManager를 만졌다
GenerateMap()의 반복되는 부분에 코드 하나 추가했으니 확인바람